### PR TITLE
Added nokogiri to gem install command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,4 @@ RUN apt-get update && apt-get install -y locales \
     && rm -rf /var/lib/apt/lists/*
 ENV LANG en_US.utf8
 
-RUN gem install minitest-reporters
+RUN gem install minitest-reporters nokogiri


### PR DESCRIPTION
Hi @Eschults ! 👋 

We're planning to organize a **Scraping with Ruby** workshop using Learn, and realized that `nokogiri` can't be required inside the code editor blocks at the moment.

I checked with @progapandist and got the suggestion to add `nokogiri` to the runner Dockerfile. Hoping you can help us merge it 🙏 